### PR TITLE
ДЗ #2 Generics

### DIFF
--- a/src/main/kotlin/ru/kotlin/homework/network/NetworkLogger.kt
+++ b/src/main/kotlin/ru/kotlin/homework/network/NetworkLogger.kt
@@ -15,9 +15,9 @@ sealed class ApiException(message: String) : Throwable(message) {
     data object UnknownException: ApiException("Unknown exception")
 }
 
-class ErrorLogger< in E : Throwable> {
+class ErrorLogger<E : Throwable> {
 
-    val errors: MutableList<Pair<LocalDateTime, @UnsafeVariance E>> = mutableListOf()
+    private val errors: MutableList<Pair<LocalDateTime, E>> = mutableListOf()
 
     fun log(response: NetworkResponse<*, E>) {
         if (response is Failure) {
@@ -31,7 +31,7 @@ class ErrorLogger< in E : Throwable> {
         }
     }
 
-    fun dump(): List<Pair<LocalDateTime, @UnsafeVariance E>> {
+    fun dump(): List<Pair<LocalDateTime, E>> {
         return errors
     }
 }
@@ -42,11 +42,13 @@ fun processThrowables(logger: ErrorLogger<Throwable>) {
     logger.log(Success(Circle))
     Thread.sleep(100)
     logger.log(Failure(IllegalArgumentException("Something unexpected")))
-
     logger.dumpLog()
+
+    val errors = logger.dump()
+    println("Errors: $errors")
 }
 
-fun processApiErrors(apiExceptionLogger: ErrorLogger<ApiException>) {
+fun processApiErrors(apiExceptionLogger: ErrorLogger<in ApiException>) {
     apiExceptionLogger.log(Success("Success"))
     Thread.sleep(100)
     apiExceptionLogger.log(Success(Circle))
@@ -54,6 +56,9 @@ fun processApiErrors(apiExceptionLogger: ErrorLogger<ApiException>) {
     apiExceptionLogger.log(Failure(ApiException.NetworkException))
 
     apiExceptionLogger.dumpLog()
+
+    val errors = apiExceptionLogger.dump()
+    println("Errors: $errors")
 }
 
 fun main() {

--- a/src/main/kotlin/ru/kotlin/homework/network/NetworkLogger.kt
+++ b/src/main/kotlin/ru/kotlin/homework/network/NetworkLogger.kt
@@ -15,9 +15,9 @@ sealed class ApiException(message: String) : Throwable(message) {
     data object UnknownException: ApiException("Unknown exception")
 }
 
-class ErrorLogger<E : Throwable> {
+class ErrorLogger< in E : Throwable> {
 
-    val errors = mutableListOf<Pair<LocalDateTime, E>>()
+    val errors: MutableList<Pair<LocalDateTime, @UnsafeVariance E>> = mutableListOf()
 
     fun log(response: NetworkResponse<*, E>) {
         if (response is Failure) {
@@ -29,6 +29,10 @@ class ErrorLogger<E : Throwable> {
         errors.forEach { (date, error) ->
             println("Error at $date: ${error.message}")
         }
+    }
+
+    fun dump(): List<Pair<LocalDateTime, @UnsafeVariance E>> {
+        return errors
     }
 }
 

--- a/src/main/kotlin/ru/kotlin/homework/network/NetworkResponse.kt
+++ b/src/main/kotlin/ru/kotlin/homework/network/NetworkResponse.kt
@@ -9,19 +9,19 @@ import java.time.LocalDateTime
 /**
  * Network result
  */
-sealed class NetworkResponse<T, R> {
+sealed class NetworkResponse<out T, out R> {
     val responseDateTime: LocalDateTime = LocalDateTime.now()
 }
 
 /**
  * Network success
  */
-data class Success<T, R>(val resp: T): NetworkResponse<T, R>()
+data class Success<out T>(val resp: T): NetworkResponse<T, Nothing>()
 
 /**
  * Network error
  */
-data class Failure<T, R>(val error: R): NetworkResponse<T, R>()
+data class Failure<out R>(val error: R): NetworkResponse<Nothing, R>()
 
 val s1 = Success("Message")
 val r11: NetworkResponse<String, Error> = s1


### PR DESCRIPTION
-- Исправьте определение классов так, чтобы все присваивания под определениями компилировались без ошибок. 
-- Почините (правильно расставьте variance параметров) класс NetworkLogger таким образом, чтобы один универсальный экземпляр логгера можно было использовать для логирования любых ошибок 
-- Сделайте так, чтобы NetworkLogger имел возможность выдать список накопленных ошибок.